### PR TITLE
Standardize error handling with HttpException (closes #10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30137,7 +30137,8 @@
         "sqlite3": "^5.1.7",
         "typeorm": "^0.3.20",
         "uniqid": "^5.4.0",
-        "url": "^0.11.3"
+        "url": "^0.11.3",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@codecov/bundle-analyzer": "^1.9.1",
@@ -31109,6 +31110,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "packages/core/manifest/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "packages/core/types": {

--- a/packages/core/manifest/src/app.module.ts
+++ b/packages/core/manifest/src/app.module.ts
@@ -32,7 +32,8 @@ import { MysqlConnectionOptions } from 'typeorm/driver/mysql/MysqlConnectionOpti
 import config from './config/config'
 import { validateEnvironment } from './config/env.validation'
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler'
-import { APP_GUARD } from '@nestjs/core'
+import { APP_FILTER, APP_GUARD } from '@nestjs/core'
+import { CoreExceptionFilter } from './core-exception.filter'
 
 @Module({
   imports: [
@@ -123,6 +124,10 @@ import { APP_GUARD } from '@nestjs/core'
     EventModule
   ],
   providers: [
+    {
+      provide: APP_FILTER,
+      useClass: CoreExceptionFilter
+    },
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard

--- a/packages/core/manifest/src/core-exception.filter.spec.ts
+++ b/packages/core/manifest/src/core-exception.filter.spec.ts
@@ -1,0 +1,147 @@
+import {
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  BadRequestException,
+  InternalServerErrorException
+} from '@nestjs/common'
+import { CoreExceptionFilter } from './core-exception.filter'
+
+describe('CoreExceptionFilter', () => {
+  let filter: CoreExceptionFilter
+  let mockResponse: any
+  let mockHost: any
+
+  beforeEach(() => {
+    filter = new CoreExceptionFilter()
+
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis()
+    }
+
+    mockHost = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getResponse: jest.fn().mockReturnValue(mockResponse)
+      })
+    }
+  })
+
+  it('should be defined', () => {
+    expect(filter).toBeDefined()
+  })
+
+  describe('HttpException handling', () => {
+    it('should handle NotFoundException with 404 status', () => {
+      const exception = new NotFoundException('Item not found')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 404,
+          message: 'Item not found'
+        })
+      )
+    })
+
+    it('should handle BadRequestException with 400 status', () => {
+      const exception = new BadRequestException('Invalid input')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 400,
+          message: 'Invalid input'
+        })
+      )
+    })
+
+    it('should handle InternalServerErrorException with 500 status', () => {
+      const exception = new InternalServerErrorException('Server error')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 500,
+          message: 'Server error'
+        })
+      )
+    })
+
+    it('should handle HttpException with string response', () => {
+      const exception = new HttpException('Custom error', 422)
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422)
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: 422,
+        message: 'Custom error'
+      })
+    })
+
+    it('should handle HttpException with object response', () => {
+      const exception = new HttpException(
+        { statusCode: 400, message: 'Bad Request', errors: ['field required'] },
+        400
+      )
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: 400,
+        message: 'Bad Request',
+        errors: ['field required']
+      })
+    })
+  })
+
+  describe('Non-HttpException handling', () => {
+    it('should handle plain Error with 500 status and generic message', () => {
+      const exception = new Error('Something broke')
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR
+      )
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        message: 'Internal server error'
+      })
+    })
+
+    it('should handle non-Error objects with 500 status and generic message', () => {
+      const exception = 'string error'
+
+      filter.catch(exception, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR
+      )
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        message: 'Internal server error'
+      })
+    })
+
+    it('should handle null/undefined exceptions', () => {
+      filter.catch(null, mockHost)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR
+      )
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        message: 'Internal server error'
+      })
+    })
+  })
+})

--- a/packages/core/manifest/src/core-exception.filter.ts
+++ b/packages/core/manifest/src/core-exception.filter.ts
@@ -1,0 +1,44 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger
+} from '@nestjs/common'
+import { Response } from 'express'
+
+@Catch()
+export class CoreExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(CoreExceptionFilter.name)
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp()
+    const response = ctx.getResponse<Response>()
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus()
+      const exceptionResponse = exception.getResponse()
+
+      response.status(status).json(
+        typeof exceptionResponse === 'string'
+          ? { statusCode: status, message: exceptionResponse }
+          : exceptionResponse
+      )
+      return
+    }
+
+    const message =
+      exception instanceof Error ? exception.message : 'Internal server error'
+
+    this.logger.error(
+      `Unhandled exception: ${message}`,
+      exception instanceof Error ? exception.stack : String(exception)
+    )
+
+    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: 'Internal server error'
+    })
+  }
+}

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcryptjs'
 import {
+  BadRequestException,
   HttpException,
   HttpStatus,
   Injectable,
@@ -258,7 +259,7 @@ export class CrudService {
       })
 
     if (!entityManifest.single && !id) {
-      throw new Error('Id is required for collections.')
+      throw new BadRequestException('Id is required for collections.')
     }
 
     const entityMetadata: EntityMetadata = this.entityService.getEntityMetadata(
@@ -399,7 +400,7 @@ export class CrudService {
       })
 
     if (!entityManifest.single && !id) {
-      throw new Error('Id is required for collections.')
+      throw new BadRequestException('Id is required for collections.')
     }
 
     const entityRepository: Repository<BaseEntity> =

--- a/packages/core/manifest/src/crud/tests/crud.service.spec.ts
+++ b/packages/core/manifest/src/crud/tests/crud.service.spec.ts
@@ -7,6 +7,7 @@ import { ValidationService } from '../../validation/services/validation.service'
 import { RelationshipService } from '../../entity/services/relationship.service'
 import { EntityManifest, Paginator, PropType } from '../../../../types/src'
 import { SelectQueryBuilder } from 'typeorm'
+import { BadRequestException, HttpException } from '@nestjs/common'
 import bcrypt from 'bcryptjs'
 
 describe('CrudService', () => {
@@ -202,14 +203,14 @@ describe('CrudService', () => {
       expect(queryBuilder.orderBy).toHaveBeenCalledWith('entity.name', 'ASC')
     })
 
-    it('should fail if the order by property is not in the entity', async () => {
+    it('should fail with HttpException if the order by property is not in the entity', async () => {
       const entitySlug = 'test'
       await expect(
         service.findAll({
           entitySlug,
           queryParams: { orderBy: 'invalid' }
         })
-      ).rejects.toThrow()
+      ).rejects.toThrow(HttpException)
     })
 
     it('should be able to order by id', async () => {
@@ -330,6 +331,17 @@ describe('CrudService', () => {
       const result = await service.findOne({ entitySlug, id: dummyItem.id })
 
       expect(result).toEqual(dummyItem)
+    })
+
+    it('should throw a BadRequestException if id is missing for collections', async () => {
+      jest.spyOn(entityManifestService, 'getEntityManifest').mockReturnValue({
+        ...dummyEntityManifest,
+        single: false
+      } as any)
+
+      await expect(
+        service.findOne({ entitySlug: 'test' })
+      ).rejects.toThrow(BadRequestException)
     })
 
     it('should throw a 404 error if the entity is not found', async () => {

--- a/packages/core/manifest/src/entity/services/entity.service.ts
+++ b/packages/core/manifest/src/entity/services/entity.service.ts
@@ -1,5 +1,9 @@
 import { BaseEntity } from '@repo/types'
-import { Injectable } from '@nestjs/common'
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException
+} from '@nestjs/common'
 import { DataSource, EntityMetadata, Repository } from 'typeorm'
 import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata'
 import { EntityManifestService } from '../../manifest/services/entity-manifest.service'
@@ -37,7 +41,7 @@ export class EntityService {
     slug?: string
   }): EntityMetadata {
     if (!className && !slug) {
-      throw new Error('Either className or slug must be provided')
+      throw new BadRequestException('Either className or slug must be provided')
     }
 
     if (slug) {
@@ -53,7 +57,7 @@ export class EntityService {
     )
 
     if (!entityMetadata) {
-      throw new Error(`Entity ${className} not found`)
+      throw new NotFoundException(`Entity ${className} not found`)
     }
 
     return entityMetadata
@@ -116,7 +120,9 @@ export class EntityService {
     entitySlug?: string
   }): Repository<BaseEntity> {
     if (!entityMetadata && !entitySlug) {
-      throw new Error('Either entityMetadata or entitySlug must be provided')
+      throw new BadRequestException(
+        'Either entityMetadata or entitySlug must be provided'
+      )
     }
 
     if (entitySlug) {

--- a/packages/core/manifest/src/entity/tests/entity.service.spec.ts
+++ b/packages/core/manifest/src/entity/tests/entity.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { Test, TestingModule } from '@nestjs/testing'
 import { EntityService } from '../services/entity.service'
 import { EntityManifestService } from '../../manifest/services/entity-manifest.service'
@@ -62,8 +63,8 @@ describe('EntityService', () => {
   })
 
   describe('getEntityMetadata', () => {
-    it('should fail if no className or slug is provided', () => {
-      expect(() => service.getEntityMetadata({})).toThrowError()
+    it('should fail with BadRequestException if no className or slug is provided', () => {
+      expect(() => service.getEntityMetadata({})).toThrow(BadRequestException)
     })
 
     it('should get entity metadata by className', () => {
@@ -93,7 +94,7 @@ describe('EntityService', () => {
       expect(result.targetName).toBe('Entity')
     })
 
-    it('should fail if no entity metadata is found', () => {
+    it('should fail with NotFoundException if no entity metadata is found', () => {
       jest.spyOn(entityManifestService, 'getEntityManifest').mockReturnValue({
         className: 'AnotherEntity'
       } as any)
@@ -102,7 +103,7 @@ describe('EntityService', () => {
         service.getEntityMetadata({
           slug: 'entity'
         })
-      ).toThrow()
+      ).toThrow(NotFoundException)
     })
   })
 
@@ -119,8 +120,8 @@ describe('EntityService', () => {
       expect(dataSource.getRepository).toHaveBeenCalledWith('Entity')
     })
 
-    it('should throw an error if no entity metadata is provided', () => {
-      expect(() => service.getEntityRepository({})).toThrow()
+    it('should throw a BadRequestException if no entity metadata is provided', () => {
+      expect(() => service.getEntityRepository({})).toThrow(BadRequestException)
     })
   })
 })

--- a/packages/core/manifest/src/handler/handler.service.spec.ts
+++ b/packages/core/manifest/src/handler/handler.service.spec.ts
@@ -2,6 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { HandlerService } from './handler.service'
 import { ConfigService } from '@nestjs/config'
 import { BackendSDK } from '../sdk/backend-sdk'
+import {
+  InternalServerErrorException,
+  NotFoundException
+} from '@nestjs/common'
 import * as fs from 'fs'
 
 jest.mock('fs', () => ({
@@ -73,15 +77,17 @@ describe('HandlerService', () => {
   })
 
   describe('importHandler', () => {
-    it('should throw an exception if the handler file does not exist', async () => {
+    it('should throw a NotFoundException if the handler file does not exist', async () => {
       ;(fs.existsSync as jest.Mock).mockReturnValue(false)
 
       await expect(service.importHandler('handler')).rejects.toThrow(
-        'Handler not found'
+        NotFoundException
       )
     })
 
-    it('should throw an exception if the handler default export is not a function', async () => {
+    it('should throw an InternalServerErrorException if the handler default export is not a function', async () => {
+      ;(fs.existsSync as jest.Mock).mockReturnValue(true)
+
       jest.spyOn(service, 'dynamicImport').mockResolvedValue(
         Promise.resolve({
           default: 'not a function'
@@ -89,7 +95,19 @@ describe('HandlerService', () => {
       )
 
       await expect(service.importHandler('handler')).rejects.toThrow(
-        'Handler not found'
+        InternalServerErrorException
+      )
+    })
+
+    it('should throw an InternalServerErrorException if dynamic import fails', async () => {
+      ;(fs.existsSync as jest.Mock).mockReturnValue(true)
+
+      jest
+        .spyOn(service, 'dynamicImport')
+        .mockRejectedValue(new Error('Module not found'))
+
+      await expect(service.importHandler('handler')).rejects.toThrow(
+        InternalServerErrorException
       )
     })
 

--- a/packages/core/manifest/src/handler/handler.service.ts
+++ b/packages/core/manifest/src/handler/handler.service.ts
@@ -1,4 +1,9 @@
-import { HttpException, Injectable } from '@nestjs/common'
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException
+} from '@nestjs/common'
 import { Request, Response } from 'express'
 import path from 'path'
 import fs from 'fs'
@@ -7,6 +12,8 @@ import { BackendSDK } from '../sdk/backend-sdk'
 
 @Injectable()
 export class HandlerService {
+  private readonly logger = new Logger(HandlerService.name)
+
   constructor(
     private configService: ConfigService,
     private readonly sdk: BackendSDK
@@ -48,14 +55,22 @@ export class HandlerService {
     )
 
     if (!fs.existsSync(handlerPath)) {
-      throw new HttpException('Handler not found', 500)
+      throw new NotFoundException('Handler not found')
     }
 
     // Import the handler.
-    const module = await this.dynamicImport(handlerPath)
+    let module: any
+    try {
+      module = await this.dynamicImport(handlerPath)
+    } catch (error) {
+      this.logger.error(
+        `Failed to import handler at ${handlerPath}: ${error instanceof Error ? error.message : error}`
+      )
+      throw new InternalServerErrorException('Failed to import handler')
+    }
 
     if (typeof module.default !== 'function') {
-      throw new HttpException('Handler is invalid', 500)
+      throw new InternalServerErrorException('Handler is invalid')
     }
 
     return module.default

--- a/packages/core/manifest/src/manifest/services/manifest.service.ts
+++ b/packages/core/manifest/src/manifest/services/manifest.service.ts
@@ -1,4 +1,9 @@
-import { Inject, Injectable, forwardRef } from '@nestjs/common'
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  forwardRef
+} from '@nestjs/common'
 import { SchemaService } from './schema.service'
 import { YamlService } from './yaml.service'
 
@@ -41,7 +46,7 @@ export class ManifestService {
    **/
   getAppManifest(options?: { fullVersion?: boolean }): AppManifest {
     if (!this.appManifest) {
-      throw new Error('Manifest not loaded')
+      throw new InternalServerErrorException('Manifest not loaded')
     }
 
     if (!options?.fullVersion) {

--- a/packages/core/manifest/src/manifest/services/yaml.service.ts
+++ b/packages/core/manifest/src/manifest/services/yaml.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common'
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common'
 
 import * as fs from 'fs'
 import * as yaml from 'js-yaml'
@@ -23,12 +23,35 @@ export class YamlService {
     if (manifestFilePath.startsWith('http')) {
       fileContent = await this.loadManifestFromUrl(manifestFilePath)
     } else {
-      fileContent = fs.readFileSync(manifestFilePath, 'utf8')
+      try {
+        fileContent = fs.readFileSync(manifestFilePath, 'utf8')
+      } catch (error) {
+        this.logger.error(
+          `Failed to read manifest file at ${manifestFilePath}: ${error instanceof Error ? error.message : error}`
+        )
+        throw new InternalServerErrorException(
+          `Failed to read manifest file at ${manifestFilePath}`
+        )
+      }
     }
 
     fileContent = this.interpolateDotEnvVariables(fileContent)
 
-    const manifestSchema: Manifest = yaml.load(fileContent) as Manifest
+    let manifestSchema: Manifest
+    try {
+      manifestSchema = yaml.load(fileContent) as Manifest
+    } catch (error) {
+      this.logger.error(
+        `Failed to parse manifest YAML: ${error instanceof Error ? error.message : error}`
+      )
+      throw new InternalServerErrorException('Failed to parse manifest YAML')
+    }
+
+    if (!manifestSchema) {
+      throw new InternalServerErrorException(
+        'Manifest YAML is empty or invalid'
+      )
+    }
 
     // Remove emojis from entity keys.
     Object.keys(manifestSchema.entities || []).forEach((key) => {
@@ -52,11 +75,23 @@ export class YamlService {
    *
    **/
   async loadManifestFromUrl(url: string): Promise<string> {
-    const response = await fetch(url).catch(() => {
-      throw new Error(`Failed to fetch the manifest from ${url}`)
+    const response = await fetch(url).catch((error) => {
+      this.logger.error(
+        `Failed to fetch the manifest from ${url}: ${error instanceof Error ? error.message : error}`
+      )
+      throw new InternalServerErrorException(
+        `Failed to fetch the manifest from ${url}`
+      )
     })
 
-    const text = await response.text()
+    const text = await response.text().catch((error) => {
+      this.logger.error(
+        `Failed to read response from ${url}: ${error instanceof Error ? error.message : error}`
+      )
+      throw new InternalServerErrorException(
+        `Failed to read manifest response from ${url}`
+      )
+    })
 
     return text
   }

--- a/packages/core/manifest/src/manifest/tests/manifest.service.spec.ts
+++ b/packages/core/manifest/src/manifest/tests/manifest.service.spec.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '@nestjs/config'
+import { InternalServerErrorException } from '@nestjs/common'
 import { Test, TestingModule } from '@nestjs/testing'
 import { AppManifest, PropType } from '@repo/types'
 import { ADMIN_ENTITY_MANIFEST } from '../../constants'
@@ -127,13 +128,13 @@ describe('ManifestService', () => {
       ).toHaveBeenCalled()
     })
 
-    it('should throw an error if the manifest is not loaded', () => {
+    it('should throw an InternalServerErrorException if the manifest is not loaded', () => {
       // Set private property.
       ;(service as any).appManifest = undefined
 
       expect(() => {
         service.getAppManifest()
-      }).toThrow()
+      }).toThrow(InternalServerErrorException)
     })
   })
 

--- a/packages/core/manifest/src/manifest/tests/yaml.service.spec.ts
+++ b/packages/core/manifest/src/manifest/tests/yaml.service.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common'
+import { InternalServerErrorException, Logger } from '@nestjs/common'
 import { Test, TestingModule } from '@nestjs/testing'
 import { YamlService } from '../services/yaml.service'
 import * as fs from 'fs'
@@ -58,21 +58,51 @@ describe('YamlService', () => {
       expect(remoteAppSchema).toEqual(dummyRemoteAppSchema)
     })
 
-    it('should throw an error if it cannot load the manifest file', async () => {
+    it('should throw an InternalServerErrorException if it cannot load the manifest file from URL', async () => {
       // Mock fetch error.
       ;(global.fetch as jest.Mock).mockImplementation(() =>
         Promise.reject('Error')
       )
 
-      expect(async () => {
-        await service.loadManifestFromUrl('wrong')
-      }).rejects.toThrow()
+      await expect(service.loadManifestFromUrl('wrong')).rejects.toThrow(
+        InternalServerErrorException
+      )
 
       // Reset
       ;(global.fetch as jest.Mock).mockImplementation(() =>
         Promise.resolve({
           text: () => Promise.resolve(JSON.stringify(dummyRemoteAppSchema))
         })
+      )
+    })
+
+    it('should throw an InternalServerErrorException if it cannot read the manifest file', async () => {
+      ;(fs.readFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory')
+      })
+
+      await expect(service.load('nonexistent/path')).rejects.toThrow(
+        InternalServerErrorException
+      )
+
+      // Reset
+      ;(fs.readFileSync as jest.Mock).mockImplementation(
+        jest.fn().mockReturnValue(JSON.stringify(dummyAppSchema))
+      )
+    })
+
+    it('should throw an InternalServerErrorException if YAML parsing fails', async () => {
+      ;(fs.readFileSync as jest.Mock).mockImplementation(
+        jest.fn().mockReturnValue('invalid: yaml: content: [')
+      )
+
+      await expect(service.load('mocked manifest path')).rejects.toThrow(
+        InternalServerErrorException
+      )
+
+      // Reset
+      ;(fs.readFileSync as jest.Mock).mockImplementation(
+        jest.fn().mockReturnValue(JSON.stringify(dummyAppSchema))
       )
     })
   })

--- a/packages/core/manifest/src/open-api/services/open-api-schema.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-schema.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, InternalServerErrorException } from '@nestjs/common'
 import { generalSchemas } from '../schemas/general-schemas'
 import {
   ReferenceObject,
@@ -105,7 +105,7 @@ export class OpenApiSchemaService {
     )
 
     if (Object.keys(schema).length === 0) {
-      throw new Error(
+      throw new InternalServerErrorException(
         `No schema found for property type: ${property.type} (${property.manifestPropType})`
       )
     }

--- a/packages/core/manifest/src/open-api/tests/open-api-schema.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api-schema.service.spec.ts
@@ -1,3 +1,4 @@
+import { InternalServerErrorException } from '@nestjs/common'
 import { Test, TestingModule } from '@nestjs/testing'
 import { OpenApiSchemaService } from '../services/open-api-schema.service'
 import {
@@ -357,7 +358,7 @@ describe('OpenApiSchemaService', () => {
       expect(schemas.NestedEntity.properties.id).toBeUndefined()
     })
 
-    it('should throw an error if the TS type is not found', () => {
+    it('should throw an InternalServerErrorException if the TS type is not found', () => {
       const invalidEntityTsTypeInfos: EntityTsTypeInfo[] = [
         {
           name: 'InvalidEntity',
@@ -373,7 +374,7 @@ describe('OpenApiSchemaService', () => {
 
       expect(() => {
         service.generateEntitySchemas(invalidEntityTsTypeInfos)
-      }).toThrow()
+      }).toThrow(InternalServerErrorException)
     })
 
     it('should create DTO types', () => {

--- a/packages/core/manifest/src/seed/services/seeder.service.ts
+++ b/packages/core/manifest/src/seed/services/seeder.service.ts
@@ -9,7 +9,7 @@ import {
   RelationshipManifest
 } from '@repo/types'
 
-import { Injectable, Logger } from '@nestjs/common'
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common'
 import { DataSource, EntityMetadata, QueryRunner, Repository } from 'typeorm'
 import { EntityService } from '../../entity/services/entity.service'
 
@@ -52,7 +52,7 @@ export class SeederService {
       const fakerModule = await import('@faker-js/faker')
       this.faker = fakerModule.faker
     } catch {
-      throw new Error(
+      throw new InternalServerErrorException(
         '@faker-js/faker is not installed. Install it with: npm install -D @faker-js/faker'
       )
     }

--- a/packages/core/manifest/src/storage/services/storage.service.ts
+++ b/packages/core/manifest/src/storage/services/storage.service.ts
@@ -1,4 +1,9 @@
-import { HttpException, Injectable } from '@nestjs/common'
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger
+} from '@nestjs/common'
 import { kebabize } from '@repo/common'
 import { DEFAULT_IMAGE_SIZES, STORAGE_PATH } from '../../constants'
 
@@ -14,6 +19,7 @@ import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 
 @Injectable()
 export class StorageService {
+  private readonly logger = new Logger(StorageService.name)
   private isS3Enabled: boolean = false
   private s3Client: S3Client
   private s3Endpoint: string
@@ -85,10 +91,17 @@ export class StorageService {
           )
         )
       ) {
-        throw new Error('Invalid file path')
+        throw new BadRequestException('Invalid file path')
       }
 
-      fs.writeFileSync(publicFolderPath, file.buffer)
+      try {
+        fs.writeFileSync(publicFolderPath, file.buffer)
+      } catch (error) {
+        this.logger.error(
+          `Failed to write file to ${publicFolderPath}: ${error instanceof Error ? error.message : error}`
+        )
+        throw new InternalServerErrorException('Failed to store file')
+      }
       return Promise.resolve(this.prependStorageUrl(filePath))
     }
   }
@@ -118,9 +131,8 @@ export class StorageService {
       const imageExtension: string = path.extname(image.originalname)
 
       if (['.jpg', '.jpeg', '.png'].indexOf(imageExtension) === -1) {
-        throw new HttpException(
-          `Unsupported image format: ${imageExtension}`,
-          400
+        throw new BadRequestException(
+          `Unsupported image format: ${imageExtension}`
         )
       }
 
@@ -152,9 +164,16 @@ export class StorageService {
             )
           )
         ) {
-          throw new Error('Invalid image path')
+          throw new BadRequestException('Invalid image path')
         }
-        fs.writeFileSync(publicFolderPath, resizedImageBuffer)
+        try {
+          fs.writeFileSync(publicFolderPath, resizedImageBuffer)
+        } catch (error) {
+          this.logger.error(
+            `Failed to write image to ${publicFolderPath}: ${error instanceof Error ? error.message : error}`
+          )
+          throw new InternalServerErrorException('Failed to store image')
+        }
         imagePaths[sizeName] = this.prependStorageUrl(imagePath)
       }
     }

--- a/packages/core/manifest/src/storage/tests/storage.service.spec.ts
+++ b/packages/core/manifest/src/storage/tests/storage.service.spec.ts
@@ -1,3 +1,7 @@
+import {
+  BadRequestException,
+  InternalServerErrorException
+} from '@nestjs/common'
 import { Test, TestingModule } from '@nestjs/testing'
 import { DEFAULT_IMAGE_SIZES } from '../../constants'
 import { ImageSizesObject } from '../../../../types/src'
@@ -194,7 +198,7 @@ describe('StorageService', () => {
       expect(sharp.prototype.toBuffer).toHaveBeenCalledTimes(2)
     })
 
-    it('should fail if the image format is unsupported', async () => {
+    it('should fail with BadRequestException if the image format is unsupported', async () => {
       const unsupportedImage = {
         buffer: Buffer.from('unsupported-image'),
         originalname: 'test.txt'
@@ -208,7 +212,34 @@ describe('StorageService', () => {
 
       await expect(
         service.storeImage(entity, property, unsupportedImage, imageSizes)
-      ).rejects.toThrow('Unsupported image format: .txt')
+      ).rejects.toThrow(BadRequestException)
+    })
+
+    it('should throw InternalServerErrorException when file write fails', () => {
+      fs.writeFileSync = jest.fn().mockImplementation(() => {
+        throw new Error('EACCES: permission denied')
+      })
+
+      expect(() =>
+        service.store(entity, property, file)
+      ).toThrow(InternalServerErrorException)
+    })
+
+    it('should throw InternalServerErrorException when image write fails', async () => {
+      jest
+        .spyOn(sharp.prototype, 'resize')
+        .mockImplementation(() => sharp.prototype)
+      jest
+        .spyOn(sharp.prototype, 'toBuffer')
+        .mockImplementation(() => Promise.resolve(Buffer.from('')))
+
+      fs.writeFileSync = jest.fn().mockImplementation(() => {
+        throw new Error('EACCES: permission denied')
+      })
+
+      await expect(
+        service.storeImage(entity, property, image, DEFAULT_IMAGE_SIZES)
+      ).rejects.toThrow(InternalServerErrorException)
     })
   })
 })


### PR DESCRIPTION
Replace plain Error objects with NestJS HttpExceptions across the codebase
for consistent API error responses. Add a global CoreExceptionFilter to
catch unhandled exceptions and return standardized JSON error responses.

- Fix incorrect 500 status codes (handler not found → 404)
- Add error boundaries around file I/O and dynamic imports
- Update and add unit tests for all changed exception types

https://claude.ai/code/session_015MPPeHJFPQUfHrBoZEe1Zx